### PR TITLE
Changed MessageBox() to MessageBoxW()

### DIFF
--- a/desktop-src/LearnWin32/example--the-open-dialog-box.md
+++ b/desktop-src/LearnWin32/example--the-open-dialog-box.md
@@ -51,7 +51,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int nCmdShow
                     // Display the file name to the user.
                     if (SUCCEEDED(hr))
                     {
-                        MessageBox(NULL, pszFilePath, L"File Path", MB_OK);
+                        MessageBoxW(NULL, pszFilePath, L"File Path", MB_OK);
                         CoTaskMemFree(pszFilePath);
                     }
                     pItem->Release();


### PR DESCRIPTION
The arguments passed into MessageBox() are wide strings, and produce an error, because MessageBox is not intended for widestrings. This change edits MessageBox -> MessageBoxW to reflect the arguments passed into it.